### PR TITLE
Logic

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 2138677392}
-  m_IndirectSpecularColor: {r: 0.2850269, g: 0.3713935, b: 0.49601045, a: 1}
+  m_IndirectSpecularColor: {r: 0.28502658, g: 0.37139314, b: 0.49600947, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:

--- a/Assets/Scripts/Manager.cs
+++ b/Assets/Scripts/Manager.cs
@@ -12,6 +12,11 @@ namespace Rails
         /// </summary>
         public const int Size = 64;
 
+        /// <summary>
+        /// The Cost for a player to use another player's track
+        /// </summary>
+        public const int AltTrackCost = 10;
+
         #region Singleton
 
         private static Manager _singleton = null;

--- a/Assets/Scripts/NodeId.cs
+++ b/Assets/Scripts/NodeId.cs
@@ -41,5 +41,12 @@ namespace Rails
 
         public static bool operator ==(NodeId n1, NodeId n2) => n1.Equals(n2);
         public static bool operator !=(NodeId n1, NodeId n2) => !n1.Equals(n2); 
+
+        public static NodeId operator +(NodeId n1, NodeId n2) => new NodeId(n1.X + n2.X, n1.Y + n2.Y);
+        public static NodeId operator -(NodeId n1, NodeId n2) => new NodeId(n1.X - n2.X, n1.Y - n2.Y);
+        public static NodeId operator *(NodeId n1, int x) => new NodeId(n1.X * x, n1.Y * x);
+
+        public static float Distance(NodeId n1, NodeId n2) =>
+            Mathf.Sqrt((float)Mathf.Pow(n1.X - n2.X, 2) + Mathf.Pow(n1.Y - n2.Y, 2));
     }
 }

--- a/Assets/Scripts/NodeId.cs
+++ b/Assets/Scripts/NodeId.cs
@@ -29,9 +29,6 @@ namespace Rails
             return false;
         }
 
-        public static bool operator ==(NodeId n1, NodeId n2) => n1.Equals(n2);
-        public static bool operator !=(NodeId n1, NodeId n2) => !n1.Equals(n2);
-
         public override int GetHashCode()
         {
             unchecked {
@@ -41,5 +38,8 @@ namespace Rails
                 return hash;
             }
         }
+
+        public static bool operator ==(NodeId n1, NodeId n2) => n1.Equals(n2);
+        public static bool operator !=(NodeId n1, NodeId n2) => !n1.Equals(n2); 
     }
 }

--- a/Assets/Scripts/Pathfinding.cs
+++ b/Assets/Scripts/Pathfinding.cs
@@ -24,20 +24,25 @@ namespace Rails
             if(!tracks.ContainsKey(start) || !tracks.ContainsKey(end))
                 return null;
 
+            // The list of nodes to return from method
+            var list = new List<NodeId>(); 
+
             // The true distances from start to considered point
             // (without A* algorithm consideration)
             var distMap = new Dictionary<NodeId, int>();
-            // The list of nodes to return from method
-            var list = new List<NodeId>(); 
             // The list of all nodes visited, connected to their
             // shortest-path neighbors.
             var previous = new Dictionary<NodeId, NodeId>();
-            // The next series of nodes to check
+            // The next series of nodes to check, sorted by minimum weight
             var queue = new SortedSet<WeightedNode>();
+            // All nodes that have been visited - ensures no node
+            // is checked twice.
             var visitedNodes = new HashSet<NodeId>();
+
             // The current considered node
             WeightedNode node;
 
+            // To start things off, add the start node to the queue
             queue.Add(new WeightedNode (start, 0));
 
             // While there are still nodes to visit,
@@ -47,6 +52,7 @@ namespace Rails
             { 
                 queue.Remove(node); 
 
+                // If the end has been traversed to, break
                 if(node.Position == end)
                     break;    
 
@@ -62,6 +68,7 @@ namespace Rails
                         distMap.Add(newPoint, node.Weight + 1);
                         previous[newPoint] = node.Position;
 
+                        // If the node hasn't been visited yet, add it to the queue
                         if(!visitedNodes.Contains(newPoint))
                         {
                             queue.Add(new WeightedNode(newPoint, node.Weight + 1));
@@ -91,7 +98,7 @@ namespace Rails
         }
 
         public static List<NodeId> LeastWeightPath(
-            Dictionary<NodeId, int[]> tracks,
+            Dictionary<NodeId, int[]> tracks, int player,
             MapData mapData, NodeId start, NodeId end
         ) {
             return null;
@@ -103,7 +110,7 @@ namespace Rails
     /// and weight to reach a node given a known start
     /// position. Used in pathfinding
     /// </summary>
-    public class WeightedNode : IComparable<WeightedNode>
+    class WeightedNode : IComparable<WeightedNode>
     {
         public NodeId Position { get; set; }
         public int Weight { get; set; }

--- a/Assets/Scripts/Utilities.cs
+++ b/Assets/Scripts/Utilities.cs
@@ -1,3 +1,5 @@
+using System;
+
 using UnityEngine;
 
 namespace Rails
@@ -42,6 +44,34 @@ namespace Rails
                 towards += (int)Cardinal.MAX_CARDINAL;
 
             return towards;
+        }
+
+        /// <summary>
+        /// Finds the Cardinal between two adjacent NodeIds.
+        /// </summary>
+        /// <param name="node1">The starting NodeId</param>
+        /// <param name="node2">The target NodeId</param>
+        /// <returns>The Cardinal represented from n1 to n2.</returns>
+        public static Cardinal CardinalBetween(NodeId node1, NodeId node2)
+        {
+            var exception = new ArgumentException("Cannot find Cardinal between two non-adjacent NodeIds");
+
+            // Find the direction the NodeIds are moving
+            var dir = node2 - node1;
+            bool isOdd = node1.X % 2 == 1;
+
+            return (dir.X, dir.Y) switch
+            {
+                ( 0,  1) => Cardinal.N,
+                ( 1,  1) => isOdd ? Cardinal.NE     : throw exception,
+                ( 1,  0) => isOdd ? Cardinal.SE     : Cardinal.NE,
+                ( 1, -1) => isOdd ? throw exception : Cardinal.SE,
+                ( 0, -1) => Cardinal.S,
+                (-1, -1) => isOdd ? throw exception : Cardinal.SW,
+                (-1,  0) => isOdd ? Cardinal.SW     : Cardinal.NW,
+                (-1,  1) => isOdd ? Cardinal.NW     : throw exception,
+                _ => throw exception,
+            };
         }
     }
 }

--- a/Assets/Scripts/Utilities.cs
+++ b/Assets/Scripts/Utilities.cs
@@ -35,7 +35,13 @@ namespace Rails
         /// </summary>
         /// <param name="towards">The Cardinal being reflected</param>
         /// <returns>The opposite cardinal direction to towards</returns> 
-        public static Cardinal ReflectCardinal(Cardinal towards) =>
-            (Cardinal)Mathf.Repeat((int)Cardinal.SW, (int)towards - 3); 
+        public static Cardinal ReflectCardinal(Cardinal towards)
+        {
+            towards -= 3;
+            if(towards < 0) 
+                towards += (int)Cardinal.MAX_CARDINAL;
+
+            return towards;
+        }
     }
 }

--- a/Assets/Scripts/UtilitiesTests.cs
+++ b/Assets/Scripts/UtilitiesTests.cs
@@ -1,0 +1,34 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Rails
+{
+    public class UtilitiesTests : MonoBehaviour
+    {
+        void Start()
+        {
+            TestReflectCardinal();    
+        }
+
+        private void TestReflectCardinal()
+        {
+            bool testFailed = false;
+            if(Utilities.ReflectCardinal(Cardinal.N) != Cardinal.S)
+                testFailed = true;
+            if(Utilities.ReflectCardinal(Cardinal.NE) != Cardinal.SW)
+                testFailed = true;
+            if(Utilities.ReflectCardinal(Cardinal.NW) != Cardinal.SE)
+                testFailed = true;
+            if(Utilities.ReflectCardinal(Cardinal.S) != Cardinal.N)
+                testFailed = true;
+            if(Utilities.ReflectCardinal(Cardinal.SW) != Cardinal.NE)
+                testFailed = true;
+            if(Utilities.ReflectCardinal(Cardinal.SE) != Cardinal.NW)
+                testFailed = true;
+
+            if(testFailed)
+                Debug.LogError("Tester: TestReflectCardinal Failed");
+        }
+    }
+}

--- a/Assets/Scripts/UtilitiesTests.cs.meta
+++ b/Assets/Scripts/UtilitiesTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 57d178e7f6698be4aa9ee5ebfb1903dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This pull request creates a new Utilities method "CardinalBetween" (finding the Cardinal between two adjacent nodes) and implements Yen's k-shortest paths, combined with shortest distance, to create a series of shortest track routes. I still need to implement a shortest path method for _building_ tracks, but first I need to test the pathfinding to make sure I'm on the right track (no pun intended). Once this branch is merged I'm going to create a new branch that creates the interface between game logic and graphics (ie. train object, track object, simple shapes like spheres and squares, etc.).