### PR TITLE
Train movement

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 2138677392}
-  m_IndirectSpecularColor: {r: 0.2850269, g: 0.3713935, b: 0.49601045, a: 1}
+  m_IndirectSpecularColor: {r: 0.28502667, g: 0.37139323, b: 0.49600998, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -367,6 +367,7 @@ GameObject:
   - component: {fileID: 1668001701}
   - component: {fileID: 1668001699}
   - component: {fileID: 1668001700}
+  - component: {fileID: 1668001702}
   m_Layer: 0
   m_Name: Manager
   m_TagString: Untagged
@@ -592,6 +593,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: bda9953e17d75874999765912debb7d0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1668001702
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1668001696}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dda3b5a5dd9749146afddeead32ed383, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1687258581
@@ -1753,6 +1766,26 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7542073940665037437, guid: 06b35d4cdf81f704a860b7c6943e6d57, type: 3}
       propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7632626451587737587, guid: 06b35d4cdf81f704a860b7c6943e6d57, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7632626451587737587, guid: 06b35d4cdf81f704a860b7c6943e6d57, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7632626451587737587, guid: 06b35d4cdf81f704a860b7c6943e6d57, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7632626451587737587, guid: 06b35d4cdf81f704a860b7c6943e6d57, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7632626451587737587, guid: 06b35d4cdf81f704a860b7c6943e6d57, type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7666871482120688445, guid: 06b35d4cdf81f704a860b7c6943e6d57, type: 3}

--- a/Assets/Scripts/Controls/GameInput.cs
+++ b/Assets/Scripts/Controls/GameInput.cs
@@ -23,7 +23,7 @@ namespace Rails.Controls
         private static Camera _mainCamera;
 
         #region Input Global Fields 
-        public static bool IsEnabled { get; set; }
+        public static bool IsEnabled { get; set; } = true;
         public static Vector2 MoveInput { get; private set; }
         public static Vector2 RotateInput { get; private set; }
         public static float ZoomInput { get; private set; }
@@ -85,7 +85,7 @@ namespace Rails.Controls
                 _mainCamera.ViewportPointToRay(new Vector3(0.5f, 0.5f)) :
                 _mainCamera.ScreenPointToRay(Mouse.current.position.ReadValue());
 
-            if (IsPointerOverUI() || IsEnabled)
+            if (IsPointerOverUI() || !IsEnabled)
                 MouseNodeId = new NodeId(-1, -1);
             else if (plane.Raycast(ray, out float enter))
                 MouseNodeId = Utilities.GetNodeId(ray.GetPoint(enter));

--- a/Assets/Scripts/Data/PlayerInfo.cs
+++ b/Assets/Scripts/Data/PlayerInfo.cs
@@ -18,7 +18,7 @@ namespace Assets.Scripts.Data
         public NodeId trainPosition;
         public bool trainPlaced;
 
-        public List<NodeId> moveSegments;
+        public List<NodeId> movePath;
         public int movePathStyle;
         public int buildPathStyle;
 
@@ -35,7 +35,7 @@ namespace Assets.Scripts.Data
             trainPosition = new NodeId(0, 0);
             trainPlaced = false;
 
-            moveSegments = new List<NodeId>();
+            movePath = new List<NodeId>();
             movePathStyle = 0;
             buildPathStyle = 0;
 

--- a/Assets/Scripts/Data/TrainCityInteraction.cs
+++ b/Assets/Scripts/Data/TrainCityInteraction.cs
@@ -1,0 +1,11 @@
+﻿using Rails.Data;
+
+namespace Assets.Scripts.Data
+{
+    public class TrainCityInteraction
+    {
+        public int PlayerIndex { get; set; }
+        public City City { get; set; }
+        public NodeId TrainPosition { get; set; }
+    }
+}

--- a/Assets/Scripts/Data/TrainCityInteraction.cs.meta
+++ b/Assets/Scripts/Data/TrainCityInteraction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4814c6e5463ed3144b94cde6007247c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Manager.cs
+++ b/Assets/Scripts/Manager.cs
@@ -12,6 +12,7 @@ using Rails.UI;
 using System.Linq;
 using Assets.Scripts.Data;
 using Rails.Collections;
+using System.Collections;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -36,6 +37,9 @@ namespace Rails {
         // Build Track
         public delegate void OnBuildTrackHandler(Manager manager);
         public event OnTurnEndEventHandler OnBuildTrack;
+
+        public EventHandler<TrainCityInteraction> OnTrainMeetsCityHandler;
+        public EventHandler OnTrainMeetsCityCompletion;
 
         #endregion
 
@@ -160,6 +164,9 @@ namespace Rails {
         private Route moveRoute = null;
         private List<Route> buildRoutes;
         private GameToken _highlightToken;
+
+        private bool _movingTrain = false;
+        private TrainMovement _trainMovement;
         #endregion
 
         #region Unity Events
@@ -169,6 +176,7 @@ namespace Rails {
             _singleton = this;
             _startRules = FindObjectOfType<GameStartRules>();
             _rules = MapData.DefaultRules;
+            _trainMovement = GetComponent<TrainMovement>();
 
             // generate start rules if empty
             if (_startRules == null) {
@@ -180,6 +188,9 @@ namespace Rails {
                     new StartPlayerInfo() { Name = "Player 2", Color = Color.blue }
                 };
             }
+
+            _trainMovement.OnMovementFinished += (_, __) => _movingTrain = false;
+            _trainMovement.OnMeetsCity += (_, interaction) => Debug.Log($"Train {interaction.PlayerIndex} meets with City {interaction.City.Name}");
         }
 
         private void Start()
@@ -204,11 +215,11 @@ namespace Rails {
                 if (currentPhase == 0 && !player.trainPlaced) {
                     Debug.Log("Place Train");
                     PlaceTrain(GameInput.MouseNodeId);
-								}
-								else {
+				}
+				else {
                     Debug.Log("Add Node");
                     AddNode(currentPath, GameInput.MouseNodeId);
-								}
+				}
             }
             if (GameInput.DeleteJustPressed) {
                 ClearPath(currentPath);
@@ -279,17 +290,34 @@ namespace Rails {
         // General gameplay methods.
 
         // Moves the train to final node in path.
-        public void MoveTrain() {
-            // Apply the Route
-            GameGraphics.MoveTrain(currentPlayer, moveRoute);
+        public void MoveTrain() => StartCoroutine(CMoveTrain());
+        private IEnumerator CMoveTrain() {
+            
+            var movePoints = Mathf.Min(_rules.TrainSpecs[player.trainStyle].movePoints, moveRoute.Distance); 
+
+            player.moveSegments.RemoveAt(0);
+            for (int i = 0; i < movePoints; ++i)
+            {
+                if (moveRoute.Nodes[i] == player.moveSegments[0])
+                    player.moveSegments.RemoveAt(0);
+            }
+
+            if(player.moveSegments[0] != player.trainPosition)
+                player.moveSegments.Insert(0, player.trainPosition);
+            
             player.trainPosition = moveRoute.Nodes.Last();
-            player.moveSegments.Insert(0, player.trainPosition);
+
+            _movingTrain = true;
+            _trainMovement.MoveTrain(currentPlayer, moveRoute.Nodes.Take(movePoints + 1).ToList());
+
+            while (_movingTrain)
+                yield return null;
 
             // Moving only updates the phase.
             GameLogic.UpdatePhase(PhasePanels, ref currentPhase, maxPhases);
             OnPhaseChange?.Invoke(this);
-            return;
         }
+
         // Discards the player's hand.
         public void DiscardHand() {
             // Remove and refill players' hand
@@ -334,6 +362,7 @@ namespace Rails {
             EndTurn();
             return;
         }
+
         // Places the current player's train at position.
         public bool PlaceTrain(NodeId position) {
             NodeType type = MapData.GetNodeAt(position).Type;
@@ -350,7 +379,9 @@ namespace Rails {
                 player.trainPlaced = true;
                 player.moveSegments.Insert(0, player.trainPosition);
                 Debug.Log("Train position = " + player.trainPosition.ToString());
-						}
+		    }
+
+            GameGraphics.PositionTrain(currentPlayer, position);
             return city;
         }
 				#endregion
@@ -390,6 +421,7 @@ namespace Rails {
             {
                 GameGraphics.HighlightRoute(moveRoute, null);
                 player.moveSegments.Clear();
+                player.moveSegments.Add(player.trainPosition);
             }
             else
             {
@@ -425,7 +457,7 @@ namespace Rails {
         public void RemoveNode(int path, int index) {
             if (currentPhase == 0) {
                 player.moveSegments.RemoveAt(index);
-						}
+		    }
             else {
                 buildPaths[path].RemoveAt(index);
 						}
@@ -447,9 +479,8 @@ namespace Rails {
         /// </summary>
         private void GameLoopSetup() {
             // Assign integers
-            //currentPlayer = 0;
+            currentPlayer = 0;
             currentPhase = -2;
-            currentPhase = 0;
             currentPath = 0;
             maxPhases = PhasePanels.Length;
 
@@ -520,15 +551,20 @@ namespace Rails {
             if (player.moveSegments.Count > 0) {
                 if (moveRoute != null) {
                     GameGraphics.HighlightRoute(moveRoute, null);
-								}
+				}
+
                 // Calculate the Route
                 moveRoute = Pathfinding.CheapestMove(
                     currentPlayer,
                     _rules.TrainSpecs[player.trainStyle].movePoints,
                     player.moveSegments.ToArray());
-                // Highlight the Route
-                GameGraphics.HighlightRoute(moveRoute, player.color);
-						}
+
+                    var movePoints = Mathf.Min(_rules.TrainSpecs[player.trainStyle].movePoints, moveRoute.Distance);
+                   
+                    // Highlight the Route
+                    GameGraphics.HighlightRoute(moveRoute.Nodes.Take(movePoints + 1).ToList(), player.color * 2.0f); 
+                    GameGraphics.HighlightRoute(moveRoute.Nodes.Take(movePoints).ToList(), player.color);
+		        }
             return;
 				}
         

--- a/Assets/Scripts/Manager.cs
+++ b/Assets/Scripts/Manager.cs
@@ -38,7 +38,7 @@ namespace Rails {
         public delegate void OnBuildTrackHandler(Manager manager);
         public event OnTurnEndEventHandler OnBuildTrack;
 
-        public EventHandler<TrainCityInteraction> OnTrainMeetsCityHandler;
+        public EventHandler<TrainCityInteraction> OnTrainMeetsCity;
         public EventHandler OnTrainMeetsCityComplete;
 
         #endregion

--- a/Assets/Scripts/Manager.cs
+++ b/Assets/Scripts/Manager.cs
@@ -39,7 +39,7 @@ namespace Rails {
         public event OnTurnEndEventHandler OnBuildTrack;
 
         public EventHandler<TrainCityInteraction> OnTrainMeetsCityHandler;
-        public EventHandler OnTrainMeetsCityCompletion;
+        public EventHandler OnTrainMeetsCityComplete;
 
         #endregion
 
@@ -190,7 +190,11 @@ namespace Rails {
             }
 
             _trainMovement.OnMovementFinished += (_, __) => _movingTrain = false;
-            _trainMovement.OnMeetsCity += (_, interaction) => Debug.Log($"Train {interaction.PlayerIndex} meets with City {interaction.City.Name}");
+            _trainMovement.OnMeetsCity += (_, interaction) =>
+            {
+                Debug.Log($"Train {interaction.PlayerIndex} meets with City {interaction.City.Name}");
+                OnTrainMeetsCityComplete?.Invoke(this, null);
+            };
         }
 
         private void Start()

--- a/Assets/Scripts/Rendering/GameGraphics.cs
+++ b/Assets/Scripts/Rendering/GameGraphics.cs
@@ -293,7 +293,9 @@ namespace Rails.Rendering
                 yield break;
             if (path == null || path.Count == 0)
                 yield break;
-
+            
+            // If this coroutine has been called on the same player again, while
+            // a previous one is still running, cancel the previous one
             if (_currentlyRunningTrains.Contains(player))
             {
                 _currentlyRunningTrains.Remove(player);
@@ -303,12 +305,12 @@ namespace Rails.Rendering
 
             var tr = _playerTrains[player].transform;
             tr.gameObject.SetActive(true);
-
+            tr.position = Utilities.GetPosition(path[0]);
+            
+            // Create a point and rotation value representing the next target for the train
             Vector3 nextPoint;
             var nextRotation = Utilities.GetCardinalRotation(Utilities.CardinalBetween(path[0], path[1]));
-
-            tr.position = Utilities.GetPosition(path[0]);
-
+            
             for (int i = 0; i < path.Count - 1; ++i)
             {
                 nextPoint = Utilities.GetPosition(path[i + 1]);

--- a/Assets/Scripts/Rendering/GameGraphics.cs
+++ b/Assets/Scripts/Rendering/GameGraphics.cs
@@ -308,7 +308,6 @@ namespace Rails.Rendering
             var nextRotation = Utilities.GetCardinalRotation(Utilities.CardinalBetween(path[0], path[1]));
 
             tr.position = Utilities.GetPosition(path[0]);
-            tr.rotation = nextRotation;
 
             for (int i = 0; i < path.Count - 1; ++i)
             {

--- a/Assets/Scripts/ScriptableObjects/MapData.cs
+++ b/Assets/Scripts/ScriptableObjects/MapData.cs
@@ -125,7 +125,20 @@ namespace Rails.ScriptableObjects
             .Where(i => Nodes[i].CityId == Cities.IndexOf(city))
             .Select(i => NodeId.FromSingleId(i))
             .ToArray();
-        
+
+        public int[] GetGoodsAtCity(City city)
+            => Cities
+                .Where(c => c == city).First()?
+                .Goods.Select(g => g.x).ToArray() ?? new int[0];
+
+        public int[] GetCitiesWithGood(Good good)
+        {
+            int goodIndex = Goods.IndexOf(good);
+            var cities = new HashSet<City>(Cities.Where(c => c.Goods.Select(g => g.x).Contains(goodIndex)));
+
+            return cities.Select(c => Cities.IndexOf(c)).ToArray();
+        }
+
         // Cache for MapData bounds
         private Bounds ? _mapNodeBounds = null;
         /// <summary>

--- a/Assets/Scripts/Systems/TrainMovement.cs
+++ b/Assets/Scripts/Systems/TrainMovement.cs
@@ -1,0 +1,62 @@
+using Assets.Scripts.Data;
+using Rails;
+using Rails.Data;
+using Rails.Rendering;
+using Rails.ScriptableObjects;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TrainMovement : MonoBehaviour
+{
+    public EventHandler<TrainCityInteraction> OnMeetsCity;
+    public EventHandler OnMovementFinished;
+
+    private MapData _mapData;
+    private GameRules _rules;
+    private bool _trainMoving = false;
+
+    private void Start()
+    {
+        _mapData = Manager.Singleton.MapData;
+        _rules = Manager.Singleton._rules;
+        GameGraphics.OnTrainMovementFinished += (_, __) => _trainMoving = false;
+    }
+
+    public void MoveTrain(int player, List<NodeId> path) => CMoveTrain(player, path);
+    private IEnumerator CMoveTrain(int player, List<NodeId> path)
+    {
+        var visitedCityIndices = new HashSet<int>();
+
+        for (int i = 0; i < path.Count; ++i)
+        {
+            // Apply the Route
+            GameGraphics.MoveTrain(player, path.GetRange(i, 2));
+            _trainMoving = true;
+            
+            // Await the GameGraphics finishing moving the train
+            while (_trainMoving) yield return null;
+
+            // Check if the current NodeId is a City with Goods
+            var node = _mapData.Nodes[path[i].GetSingleId()];
+
+            if(
+                node.Type == (NodeType.MajorCity | NodeType.MediumCity | NodeType.SmallCity)
+                && !visitedCityIndices.Contains(node.CityId)
+                && _mapData.Cities[node.CityId].Goods.Count > 0
+            ) {
+                OnMeetsCity?.Invoke(this, new TrainCityInteraction
+                {
+                    PlayerIndex = player,
+                    TrainPosition = path[i],
+                    City = _mapData.Cities[node.CityId]
+                });
+            }
+
+            yield return null;
+        }
+
+        OnMovementFinished?.Invoke(this, null);
+    }
+}

--- a/Assets/Scripts/Systems/TrainMovement.cs
+++ b/Assets/Scripts/Systems/TrainMovement.cs
@@ -8,13 +8,27 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+/// <summary>
+/// Implements the movement of trains, synchronizing
+/// with the Manager and GameGraphics to create a step by
+/// step progression from node to node, and interaction with
+/// cities.
+/// </summary>
 public class TrainMovement : MonoBehaviour
 {
+    /// <summary>
+    /// Invoked when the train hits a City with Goods
+    /// </summary>
     public EventHandler<TrainCityInteraction> OnMeetsCity;
+    /// <summary>
+    /// Invoked when the TrainMovement has completed a train's movement
+    /// </summary>
     public EventHandler OnMovementFinished;
 
     private MapData _mapData;
     private bool _trainMoving = false;
+
+    // Is the player still choosing whether to load new Goods at a city?
     private bool _awaitingGUI = false;
 
     private void Start()
@@ -23,16 +37,22 @@ public class TrainMovement : MonoBehaviour
         Manager.Singleton.OnTrainMeetsCityComplete += (__, _) => _awaitingGUI = false;
         GameGraphics.OnTrainMovementFinished += (_, __) => _trainMoving = false;
     }
-
-    public void MoveTrain(int player, List<NodeId> path) => StartCoroutine(CMoveTrain(player, path));
-    private IEnumerator CMoveTrain(int player, List<NodeId> path)
+    
+    /// <summary>
+    /// Moves a player's train along the given path, stopping and
+    /// invoking interactions events when the train meets a City.
+    /// </summary>
+    /// <param name="playerIndex"></param>
+    /// <param name="path"></param>
+    public void MoveTrain(int playerIndex, List<NodeId> path) => StartCoroutine(CMoveTrain(playerIndex, path));
+    private IEnumerator CMoveTrain(int playerIndex, List<NodeId> path)
     {
         var visitedCityIndices = new HashSet<int>();
 
         for (int i = 0; i < path.Count - 1; ++i)
         {
             // Apply the Route
-            GameGraphics.MoveTrain(player, path.GetRange(i, 2));
+            GameGraphics.MoveTrain(playerIndex, path.GetRange(i, 2));
             _trainMoving = true;
             
             // Await the GameGraphics finishing moving the train
@@ -40,7 +60,9 @@ public class TrainMovement : MonoBehaviour
 
             // Check if the current NodeId is a City with Goods
             var node = _mapData.Nodes[path[i+1].GetSingleId()];
-
+            
+            // If the city hasn't been already visited, and if
+            // it has any goods, invoke the interaction method
             if(
                 (node.Type == NodeType.MajorCity  ||
                 node.Type == NodeType.MediumCity ||
@@ -50,10 +72,12 @@ public class TrainMovement : MonoBehaviour
             ) {
                 _awaitingGUI = true;
                 visitedCityIndices.Add(node.CityId);
-
+                
+                // Invoke the Manager OnMeetsCity method with the provided
+                // interaction arguments
                 OnMeetsCity?.Invoke(this, new TrainCityInteraction
                 {
-                    PlayerIndex = player,
+                    PlayerIndex = playerIndex,
                     TrainPosition = path[i],
                     City = _mapData.Cities[node.CityId]
                 });

--- a/Assets/Scripts/Systems/TrainMovement.cs.meta
+++ b/Assets/Scripts/Systems/TrainMovement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dda3b5a5dd9749146afddeead32ed383
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Implemented train movement, using a new `Monobehaviour` and coroutines. `_trainMovement` is a new component added to the `Manager` which can be used to trigger movement. The `TrainMovement` `Monobehaviour` Invokes an `EventHandler` named `OnTrainMeetsCity` for UI toggling. Once UI is complete it can trigger `OnTrainMeetsCityComplete`, which will inform the `TrainMovement` to continue down the path.

`OnTrainMeetsCity` sends an argument of type `TrainCityInteraction` which contains the player index, `City` value, and `NodeId` position.

A new private variable named `_trainMoving` has been created in the `Manager`, and is toggled / untoggled when the move process starts. This can be used to prevent the game from continuing when a train is progressing, and picking up various `Good`s from `City`s.